### PR TITLE
Remove tech list from footer

### DIFF
--- a/src/_includes/main.njk
+++ b/src/_includes/main.njk
@@ -56,7 +56,6 @@ description: "Hull Blogs provides aggregated content from University of Hull stu
 			<p>Powered by <a href="https://freeside.co.uk/"><img class="large-icon" src="{% asset 'images/freeside.svg' %}" alt="Freeside logo" aria-hidden="true" /> Freeside</a></p>
 			<p>hullblogs.com built with ❤️ by <a href="https://starbeamrainbowlabs.com/"><img class="large-icon" src="{% asset 'https://starbeamrainbowlabs.com/images/sbrl/SBRL-Small-200.png' %}" alt="Starbeamrainbowlabs' logo" aria-hidden="true" />Starbeamrainbowlabs</p>
 			
-			<p>Tech: <a href="https://www.11ty.dev/">Eleventy</a> (this website), <a href="https://useiconic.com/open">Open Iconic</a> (icons)<!--, <a href="https://www.heropatterns.com/">Hero Patterns</a> (background patterns)-->, <a href="https://github.com/shssoichiro/oxipng">Oxipng</a> (PNG image compression), <a href="https://www.npmjs.com/package/feedme"><code>feedme</code></a> (for parsing feeds)</p>
 			<p>Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache Licence 2.0</a> (<a href="https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)">tldr</a>)</p>
 		</footer>
 	</body>


### PR DESCRIPTION
Can we remove the tech list from the footer of Hull Blogs so that it doesn't look so cramped please? This information can be found on the README etc, can't it? 

Please see suggested changes. 