### PR TITLE
update crimsontome blog feed url

### DIFF
--- a/feeds.json
+++ b/feeds.json
@@ -12,7 +12,7 @@
 	{
 		"author_name": "Matt Clark",
 		"github_username": "CrimsonTome",
-		"feed_uri": "https://crimsontome.com/feed/feed.xml"
+		"feed_uri": "https://blog.crimsontome.com/feed/feed.xml"
 	},
 	{
 		"author_name": "George Kokinis",


### PR DESCRIPTION
since crimsontome.com is broken (base url), blog has been moved to blog.crimsontome.com